### PR TITLE
Just use mower name as mower name

### DIFF
--- a/custom_components/husqvarna_automower/device_tracker.py
+++ b/custom_components/husqvarna_automower/device_tracker.py
@@ -48,21 +48,14 @@ class AutomowerTracker(TrackerEntity, HusqvarnaEntity, CoordinatorEntity):
         self.mower_attributes = self.mower["attributes"]
         self.connected = self.mower_attributes["metadata"]["connected"]
         self.mower_id = self.mower["id"]
-        self.mower_name = f"{self.mower_attributes['system']['model']}_{self.mower_attributes['system']['name']}"
-        self.model_string_splited = self.mower_attributes["system"]["model"].split(" ")
-        try:
-            self.model = (
-                f"{self.model_string_splited[1]} {self.model_string_splited[2]}"
-            )
-        except IndexError:
-            self.model = self.mower_attributes["system"]["model"]
-        self.mower_name = f"{self.model}_{self.mower_attributes['system']['name']}"
+        self.mower_name = self.mower_attributes["system"]["name"]
+        self.model = self.mower_attributes["system"]["model"]
 
     @property
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.mower_id)},
-            "name": self.mower_attributes["system"]["name"],
+            "name": self.mower_name,
             "manufacturer": "Husqvarna",
             "model": self.model,
         }

--- a/custom_components/husqvarna_automower/device_tracker.py
+++ b/custom_components/husqvarna_automower/device_tracker.py
@@ -63,7 +63,7 @@ class AutomowerTracker(TrackerEntity, HusqvarnaEntity, CoordinatorEntity):
     @property
     def name(self):
         """Return the name of the entity."""
-        return f"{self.mower_name}_Device Tracker"
+        return self.mower_name
 
     @property
     def unique_id(self):

--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -98,21 +98,14 @@ class HusqvarnaAutomowerEntity(HusqvarnaEntity, StateVacuumEntity, CoordinatorEn
         self.attributes = None
         self.payload = None
         self.communication_not_possible_already_sent = False
-        self.mower_name = f"{self.mower_attributes['system']['model']}_{self.mower_attributes['system']['name']}"
-        self.model_string_splited = self.mower_attributes["system"]["model"].split(" ")
-        try:
-            self.model = (
-                f"{self.model_string_splited[1]} {self.model_string_splited[2]}"
-            )
-        except IndexError:
-            self.model = self.mower_attributes["system"]["model"]
-        self.mower_name = f"{self.model}_{self.mower_attributes['system']['name']}"
+        self.mower_name = self.mower_attributes["system"]["name"]
+        self.model = self.mower_attributes["system"]["model"]
 
     @property
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.mower_id)},
-            "name": self.mower_attributes["system"]["name"],
+            "name": self.mower_name,
             "manufacturer": "Husqvarna",
             "model": self.model,
         }


### PR DESCRIPTION
The Automower integration should just pass the name as presented in the Husqvarna API and not mangle it in inconsistent ways. Mangling should be deferred to lovelace or someplace else, the model of the mower is available through the device_info property, so it's still accessible.