### PR TITLE
Store token to config entry on update

### DIFF
--- a/custom_components/husqvarna_automower/__init__.py
+++ b/custom_components/husqvarna_automower/__init__.py
@@ -50,6 +50,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     access_token = entry.data.get(CONF_TOKEN)
 
     session = aioautomower.AutomowerSession(api_key, access_token)
+    session.register_token_callback(
+        lambda token: hass.config_entries.async_update_entry(
+            entry,
+            data={
+                CONF_TOKEN: token,
+            },
+        )
+    )
 
     try:
         await session.connect()

--- a/custom_components/husqvarna_automower/manifest.json
+++ b/custom_components/husqvarna_automower/manifest.json
@@ -11,7 +11,7 @@
     "@Thomas55555"
   ],
   "requirements": [
-    "aioautomower==2021.10.2"
+    "aioautomower==2021.10.3"
   ],
   "iot_class": "cloud_push",
   "version": "0.0.0"


### PR DESCRIPTION
With this PR, new tokens are stored on each update:

<pre>
homeassistant    | 2021-10-14 09:11:00 DEBUG (MainThread) [aioautomower.session] Refresh access token
homeassistant    | 2021-10-14 09:11:00 DEBUG (MainThread) [aioautomower.rest] Resp.status refresh token: 200
homeassistant    | 2021-10-14 09:11:00 DEBUG (MainThread) [aioautomower.session] <b>Schedule token callback &lt;function async_setup_entry.&lt;locals&gt;.&lt;lambda&gt; at 0x7f961d84b4c0&gt;</b>
homeassistant    | 2021-10-14 09:11:00 DEBUG (MainThread) [aioautomower.rest] Resp.status mower data: 200
homeassistant    | 2021-10-14 09:11:00 DEBUG (MainThread) [aioautomower.session] _token_monitor_task sleeping for 86338.75075125694 sec
</pre>