### PR TITLE
add cuttingheight setting

### DIFF
--- a/custom_components/husqvarna_automower/const.py
+++ b/custom_components/husqvarna_automower/const.py
@@ -13,7 +13,7 @@ ICON = "mdi:robot-mower"
 
 
 # Platforms
-PLATFORMS = ["device_tracker", "vacuum", "select"]
+PLATFORMS = ["device_tracker", "vacuum", "select", "number"]
 
 
 # Configuration and options

--- a/custom_components/husqvarna_automower/number.py
+++ b/custom_components/husqvarna_automower/number.py
@@ -1,0 +1,97 @@
+"""Platform for Husqvarna Automower device tracker integration."""
+import logging
+import json
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import UpdateFailed
+import aioautomower
+from homeassistant.const import CONF_TOKEN
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_devices) -> None:
+    """Setup sensor platform."""
+
+    session = hass.data[DOMAIN][entry.entry_id]
+    _LOGGER.debug("Model %s", session.data["data"])
+    async_add_devices(
+        AutomowerNumber(session, idx) for idx in enumerate(session.data["data"])
+    )
+
+
+class AutomowerNumber(NumberEntity):
+    """Defining the Device Tracker Entity."""
+
+    def __init__(self, session, idx) -> None:
+        self.session = session
+        self.idx = idx
+        self.mower = self.session.data["data"][self.idx]
+
+        mower_attributes = self.__get_mower_attributes()
+        self.mower_id = self.mower["id"]
+        self.mower_name = mower_attributes["system"]["name"]
+        self.model = mower_attributes["system"]["model"]
+
+        self.session.register_cb(
+            lambda _: self.async_write_ha_state(), schedule_immediately=True
+        )
+
+        self._attr_current_option = mower_attributes["settings"]["headlight"]["mode"]
+
+    def __get_mower_attributes(self) -> dict:
+        return self.session.data["data"][self.idx]["attributes"]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self.mower_id)})
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return f"{self.mower_name}_cuttingheight"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return f"{self.mower_id}_cuttingheight"
+
+    @property
+    def min_value(self) -> float:
+        """Return the minimum value."""
+        return 1
+
+    @property
+    def max_value(self) -> float:
+        """Return the maximum value."""
+        return 9
+
+    @property
+    def value(self) -> int:
+        """Return the entity value."""
+        mower_attributes = self.__get_mower_attributes()
+        return mower_attributes["settings"]["cuttingHeight"]
+
+    async def async_set_value(self, value: float) -> None:
+        """Change the selected option."""
+        mower_attributes = self.__get_mower_attributes()
+        command_type = "settings"
+        string = {
+            "data": {
+                "type": "settings",
+                "attributes": {
+                    "cuttingHeight": value,
+                    "headlight": {
+                        "mode": mower_attributes["settings"]["headlight"]["mode"]
+                    },
+                },
+            }
+        }
+        payload = json.dumps(string)
+        try:
+            await self.session.action(self.mower_id, payload, command_type)
+        except Exception as exception:
+            raise UpdateFailed(exception) from exception

--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -279,7 +279,7 @@ class HusqvarnaAutomowerEntity(StateVacuumEntity):
                 time.gmtime((mower_attributes["planner"]["nextStartTimestamp"]) / 1000),
             )
 
-        attributes = {
+        return {
             ATTR_STATUS: self.__get_status(),
             "mode": mower_attributes["mower"]["mode"],
             "activity": mower_attributes["mower"]["activity"],
@@ -289,13 +289,7 @@ class HusqvarnaAutomowerEntity(StateVacuumEntity):
             "nextStart": next_start,
             "action": mower_attributes["planner"]["override"]["action"],
             "restrictedReason": mower_attributes["planner"]["restrictedReason"],
-            "headlight": mower_attributes["settings"]["headlight"]["mode"],
         }
-
-        if "4" in self.model:
-            attributes["cuttingHeight"] = mower_attributes["settings"]["cuttingHeight"]
-
-        return attributes
 
     async def async_start(self) -> None:
         """Resume schedule."""


### PR DESCRIPTION
Hi @simontegelid
If you have time, I might need your help again. I added an entity to set the cuttingheight for the mower. But I want that this entity is only working for mowers of der 4xx series, because otherwise the entity is useless. Do you know, how I can only add mowers, which have a `4`in the model name?
I think I should at something in line 22 like `if "4" in models`, but I don't get the syntax.