### PR TITLE
fix availability

### DIFF
--- a/custom_components/husqvarna_automower/entity.py
+++ b/custom_components/husqvarna_automower/entity.py
@@ -3,8 +3,8 @@
 import logging
 
 from homeassistant.helpers.entity import DeviceInfo, Entity
-
 from homeassistant.util import dt as dt_util
+
 from .const import DOMAIN, HUSQVARNA_URL
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
with Rest we found in the metadata, that the mower is not connected anymore. This information is still used for start-up of home assistant. But if the mower is not connected anymore, there are no update of the metadata, in the websocket. Regularly, the websocket is pushing an update every 14min. So if two updates are missing, we assume, that the mower is not available anymore.