### PR TITLE
downgrade requirements of numpy

### DIFF
--- a/custom_components/husqvarna_automower/manifest.json
+++ b/custom_components/husqvarna_automower/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "aioautomower==2022.6.0",
     "geopy>=2.1.0",
-    "numpy>=1.22.4",
+    "numpy>=1.21.6",
     "Pillow>=9.1.1"
   ],
   "iot_class": "cloud_push",


### PR DESCRIPTION
Home Assistant has numpy fixed on version 1.21.6.
So there is a conflict now.
Will the camera also work with 1.21.6?
@prairiesnpr