### PR TITLE
Add Location Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,18 @@ You have two options to login.
 
 The optional camera entity is disabled by default.  The camera entity will plot the current coordinates and location history of the mower on a user provided image. To configure the entity you need to upload your desired map image and determine the coordinates of the top left corner and the bottom right corner of your selected image.
 
-The camera entity is configured via the configure option on the integration. To enter the coordinates, ensure that they are in Signed Degree format and seperated by a comma for example (40.689209, -74.044661)
+The camera entity is configured via the configure option on the integration. To enter the coordinates, ensure that they are in Signed Degree format and seperated by a comma for example ```40.689209, -74.044661```
 
 You can then provide the path to the image you would like to use for the map and mower, this has been tested with the PNG format, other formats may work.
+
+
+### Configuring the zone sensor
+
+The optional zone sensor allows zones to be designated by coorinates, this sensor will then return the name of the zone the mower is currently located.
+
+To create a Zone, select new then enter a name for the zone and the coordinates of the zone.  Coordinates are entered in Signed Degree format with latitude and lognitude seperated by a comma and each coordinate seperated by a semi colon. You must enter at least three coordinates to define a zone. For example: ```40.689209, -74.044661; 40.689210, -74.044652; 40.689211, -74.044655``` You must select save and then submit, exiting the flow in another manner will cause any entered zones to be lost.
+
+If a Home Zone is set, the sensor will return Home when the mower is charging or at the docking station.
 
 ## Usage
 

--- a/custom_components/husqvarna_automower/binary_sensor.py
+++ b/custom_components/husqvarna_automower/binary_sensor.py
@@ -76,39 +76,3 @@ class AutomowerLeavingDockBinarySensor(BinarySensorEntity, AutomowerEntity):
             return True
         if mower_attributes["mower"]["activity"] != "LEAVING":
             return False
-
-
-class AutomowerErrorBinarySensor(BinarySensorEntity, AutomowerEntity):
-    """Defining the AutomowerErrorSensor Entity."""
-
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(self, session, idx):
-        super().__init__(session, idx)
-        self._attr_name = f"{self.mower_name} Error"
-        self._attr_unique_id = f"{self.mower_id}_error"
-
-    @property
-    def is_on(self) -> bool:
-        """Return if the mower is in an error status."""
-        mower_attributes = AutomowerEntity.get_mower_attributes(self)
-        if mower_attributes["mower"]["state"] in [
-            "ERROR",
-            "FATAL_ERROR",
-            "ERROR_AT_POWER_UP",
-        ]:
-            return True
-        return False
-
-    @property
-    def extra_state_attributes(self) -> dict:
-        """Return the specific state attributes of this mower."""
-        mower_attributes = AutomowerEntity.get_mower_attributes(self)
-        if self.is_on:
-            return {
-                "error_code": int(mower_attributes["mower"]["errorCode"]),
-                "description": ERRORCODES.get(mower_attributes["mower"]["errorCode"]),
-            }
-
-        return {"error_code": -1, "description": "No Error"}

--- a/custom_components/husqvarna_automower/binary_sensor.py
+++ b/custom_components/husqvarna_automower/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, ERRORCODES
 from .entity import AutomowerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +27,10 @@ async def async_setup_entry(
     )
     async_add_entities(
         AutomowerLeavingDockBinarySensor(session, idx)
+        for idx, ent in enumerate(session.data["data"])
+    )
+    async_add_entities(
+        AutomowerErrorBinarySensor(session, idx)
         for idx, ent in enumerate(session.data["data"])
     )
 
@@ -72,3 +76,39 @@ class AutomowerLeavingDockBinarySensor(BinarySensorEntity, AutomowerEntity):
             return True
         if mower_attributes["mower"]["activity"] != "LEAVING":
             return False
+
+
+class AutomowerErrorBinarySensor(BinarySensorEntity, AutomowerEntity):
+    """Defining the AutomowerErrorSensor Entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, session, idx):
+        super().__init__(session, idx)
+        self._attr_name = f"{self.mower_name} Error"
+        self._attr_unique_id = f"{self.mower_id}_error"
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the mower is in an error status."""
+        mower_attributes = AutomowerEntity.get_mower_attributes(self)
+        if mower_attributes["mower"]["state"] in [
+            "ERROR",
+            "FATAL_ERROR",
+            "ERROR_AT_POWER_UP",
+        ]:
+            return True
+        return False
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the specific state attributes of this mower."""
+        mower_attributes = AutomowerEntity.get_mower_attributes(self)
+        if self.is_on:
+            return {
+                "error_code": int(mower_attributes["mower"]["errorCode"]),
+                "description": ERRORCODES.get(mower_attributes["mower"]["errorCode"]),
+            }
+
+        return {"error_code": -1, "description": "No Error"}

--- a/custom_components/husqvarna_automower/config_flow.py
+++ b/custom_components/husqvarna_automower/config_flow.py
@@ -1,12 +1,14 @@
 """Config flow to add the integration via the UI."""
 import logging
 import os
+import json
 
 from aiohttp.client_exceptions import ClientConnectorError, ClientResponseError
 import voluptuous as vol
 
 from aioautomower import GetAccessToken, GetMowerData, TokenError
 from homeassistant import data_entry_flow, config_entries
+from homeassistant.helpers.selector import selector
 
 
 from homeassistant.const import (
@@ -31,6 +33,14 @@ from .const import (
     GPS_BOTTOM_RIGHT,
     MOWER_IMG_PATH,
     MAP_IMG_PATH,
+    CONF_ZONES,
+    ZONE_COORD,
+    ZONE_NAME,
+    ZONE_DEL,
+    ZONE_SEL,
+    ZONE_NEW,
+    ZONE_FINISH,
+    HOME_LOCATION,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -200,71 +210,183 @@ class HusqvarnaConfigFlowHandler(
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         super().__init__()
         self.base_path = os.path.dirname(__file__)
         self.config_entry = config_entry
 
-        self.camera_enabled = self.config_entry.options.get(ENABLE_CAMERA, False)
-        self.map_top_left_coord = self.config_entry.options.get(GPS_TOP_LEFT, "")
+        self.user_input = dict(config_entry.options)
+        if self.user_input.get(CONF_ZONES, False):
+            self.user_input[CONF_ZONES] = json.loads(self.user_input[CONF_ZONES])
+
+        self.configured_zones = self.user_input.get(CONF_ZONES, {})
+
+        self.camera_enabled = self.user_input.get(ENABLE_CAMERA, False)
+        self.map_top_left_coord = self.user_input.get(GPS_TOP_LEFT, "")
         if self.map_top_left_coord != "":
             self.map_top_left_coord = ",".join(
                 [str(x) for x in self.map_top_left_coord]
             )
 
-        self.map_bottom_right_coord = self.config_entry.options.get(
-            GPS_BOTTOM_RIGHT, ""
-        )
+        self.map_bottom_right_coord = self.user_input.get(GPS_BOTTOM_RIGHT, "")
         if self.map_bottom_right_coord != "":
             self.map_bottom_right_coord = ",".join(
                 [str(x) for x in self.map_bottom_right_coord]
             )
 
-        self.mower_image_path = self.config_entry.options.get(
+        self.mower_image_path = self.user_input.get(
             MOWER_IMG_PATH, os.path.join(self.base_path, "resources/mower.png")
         )
-        self.map_img_path = self.config_entry.options.get(
+        self.map_img_path = self.user_input.get(
             MAP_IMG_PATH, os.path.join(self.base_path, "resources/map_image.png")
         )
-        self.options = self.config_entry.options.copy()
+
+        self.home_location = self.user_input.get(HOME_LOCATION, "")
+        if self.home_location != "":
+            self.home_location = ",".join([str(x) for x in self.home_location])
+
+        self.sel_zone_id = None
 
     async def async_step_init(self, user_input=None):
+        """Manage option flow"""
+        return await self.async_step_select()
+
+    async def async_step_select(self, user_input=None):
+        """Select Configuration Item"""
+
+        return self.async_show_menu(
+            step_id="select",
+            menu_options=["geofence_init", "camera_init", "home_init"],
+        )
+
+    async def async_step_home_init(self, user_input=None):
+        """Configure the home location."""
+
+        if user_input:
+            if user_input.get(HOME_LOCATION):
+                self.user_input[HOME_LOCATION] = [
+                    float(x.strip())
+                    for x in user_input.get(HOME_LOCATION).split(",")
+                    if x
+                ]
+                return await self._update_options()
+        data_schema = vol.Schema(
+            {
+                vol.Required(HOME_LOCATION, default=self.home_location): str,
+            }
+        )
+        return self.async_show_form(step_id="home_init", data_schema=data_schema)
+
+    async def async_step_geofence_init(self, user_input=None):
+        """Configure the geofence"""
+
+        if user_input:
+            self.sel_zone_id = user_input.get(ZONE_SEL, ZONE_NEW)
+            if self.sel_zone_id == ZONE_FINISH:
+                return await self._update_options()
+
+            return await self.async_step_zone_edit()
+
+        configured_zone_keys = [ZONE_NEW, ZONE_FINISH] + list(
+            self.configured_zones.keys()
+        )
+        data_schema = {}
+        data_schema[ZONE_SEL] = selector(
+            {
+                "select": {
+                    "options": configured_zone_keys,
+                }
+            }
+        )
+        return self.async_show_form(
+            step_id="geofence_init", data_schema=vol.Schema(data_schema)
+        )
+
+    async def async_step_zone_edit(self, user_input=None):
+        """Update the selected zone configuration."""
+        if user_input:
+            if user_input.get(ZONE_DEL) is True:
+                self.configured_zones.pop(self.sel_zone_id, None)
+            else:
+                zone_coord = []
+                if user_input.get(ZONE_COORD):
+                    for coord in user_input.get(ZONE_COORD).split(";"):
+                        if coord != "":
+                            coord_split = coord.split(",")
+                            zone_coord.append(
+                                (float(coord_split[0]), float(coord_split[1]))
+                            )
+                    if self.sel_zone_id == ZONE_NEW:
+                        self.sel_zone_id = (
+                            user_input.get(ZONE_NAME).lower().strip().replace(" ", "_")
+                        )
+
+                    self.configured_zones[self.sel_zone_id] = {
+                        ZONE_COORD: zone_coord,
+                        ZONE_NAME: user_input.get(ZONE_NAME).strip(),
+                    }
+
+            self.user_input.update({CONF_ZONES: self.configured_zones})
+            return await self.async_step_geofence_init()
+
+        sel_zone = self.configured_zones.get(self.sel_zone_id, {})
+        current_coordinates = sel_zone.get(ZONE_COORD, "")
+
+        str_zone = ""
+        sel_zone_name = sel_zone.get(ZONE_NAME, "")
+
+        for coord in current_coordinates:
+            str_zone += ",".join([str(x) for x in coord])
+            str_zone += ";"
+
+        sel_zone_coordinates = str_zone
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(ZONE_NAME, default=sel_zone_name): str,
+                vol.Required(ZONE_COORD, default=sel_zone_coordinates): str,
+                vol.Required(ZONE_DEL, default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="zone_edit", data_schema=data_schema)
+
+    async def async_step_camera_init(self, user_input=None):
         """Enable / Disable the camera."""
 
         if user_input:
             if user_input.get(ENABLE_CAMERA):
-                self.options[ENABLE_CAMERA] = True
-                return await self.async_step_config()
-            self.options[ENABLE_CAMERA] = False
-            return await self._update_camera_config()
+                self.user_input[ENABLE_CAMERA] = True
+                return await self.async_step_camera_config()
+            self.user_input[ENABLE_CAMERA] = False
+            return await self._update_options()
 
         data_schema = vol.Schema(
             {
                 vol.Required(ENABLE_CAMERA, default=self.camera_enabled): bool,
             }
         )
-        return self.async_show_form(step_id="init", data_schema=data_schema)
+        return self.async_show_form(step_id="camera_init", data_schema=data_schema)
 
-    async def async_step_config(self, user_input=None):
+    async def async_step_camera_config(self, user_input=None):
         """Update the camera configuration."""
         if user_input:
             if user_input.get(GPS_TOP_LEFT):
-                self.options[GPS_TOP_LEFT] = [
+                self.user_input[GPS_TOP_LEFT] = [
                     float(x.strip())
                     for x in user_input.get(GPS_TOP_LEFT).split(",")
                     if x
                 ]
             if user_input.get(GPS_BOTTOM_RIGHT):
-                self.options[GPS_BOTTOM_RIGHT] = [
+                self.user_input[GPS_BOTTOM_RIGHT] = [
                     float(x.strip())
                     for x in user_input.get(GPS_BOTTOM_RIGHT).split(",")
                     if x
                 ]
 
-            self.options[MOWER_IMG_PATH] = user_input.get(MOWER_IMG_PATH)
-            self.options[MAP_IMG_PATH] = user_input.get(MAP_IMG_PATH)
-            return await self._update_camera_config()
+            self.user_input[MOWER_IMG_PATH] = user_input.get(MOWER_IMG_PATH)
+            self.user_input[MAP_IMG_PATH] = user_input.get(MAP_IMG_PATH)
+            return await self._update_options()
 
         data_schema = vol.Schema(
             {
@@ -276,8 +398,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(MAP_IMG_PATH, default=self.map_img_path): str,
             }
         )
-        return self.async_show_form(step_id="config", data_schema=data_schema)
+        return self.async_show_form(step_id="camera_config", data_schema=data_schema)
 
-    async def _update_camera_config(self):
+    async def _update_options(self):
         """Update config entry options."""
-        return self.async_create_entry(title="", data=self.options)
+
+        self.user_input[CONF_ZONES] = json.dumps(self.user_input.get(CONF_ZONES, {}))
+        return self.async_create_entry(title="", data=self.user_input)

--- a/custom_components/husqvarna_automower/const.py
+++ b/custom_components/husqvarna_automower/const.py
@@ -31,6 +31,7 @@ CONF_TOKEN_TYPE = "token_type"
 CONF_REFRESH_TOKEN = "refresh_token"
 ACCESS_TOKEN_RAW = "access_token_raw"
 POSITIONS = "positions"
+HOME_LOCATION = "home_location"
 
 # Camera configuration
 ENABLE_CAMERA = "enable_camera"
@@ -38,6 +39,16 @@ GPS_TOP_LEFT = "gps_top_left"
 GPS_BOTTOM_RIGHT = "gps_bottom_right"
 MOWER_IMG_PATH = "mower_img_path"
 MAP_IMG_PATH = "map_img_path"
+
+# Zone configuration
+CONF_ZONES = "configured_zones"
+ZONE_COORD = "zone_coordinates"
+ZONE_NAME = "name"
+ZONE_DEL = "delete"
+ZONE_SEL = "selected_zone"
+ZONE_NEW = "new"
+ZONE_ID = "zone_id"
+ZONE_FINISH = "save"
 
 
 # Defaults

--- a/custom_components/husqvarna_automower/manifest.json
+++ b/custom_components/husqvarna_automower/manifest.json
@@ -14,7 +14,8 @@
     "aioautomower==2022.6.0",
     "geopy>=2.1.0",
     "numpy>=1.21.6",
-    "Pillow>=9.1.1"
+    "Pillow>=9.1.1",
+    "Shapely>=1.8.2"
   ],
   "iot_class": "cloud_push",
   "version": "0.0.0"

--- a/custom_components/husqvarna_automower/translations/en.json
+++ b/custom_components/husqvarna_automower/translations/en.json
@@ -35,14 +35,38 @@
     },
     "options": {
         "step": {
-            "init": {
+            "select": {
+                "menu_options": {
+                    "home_init": "Set Home Location",
+                    "geofence_init": "Setup Zones",
+                    "camera_init": "Configure Map Camera"
+                },
+                "description": "Select Config Option",
+                "title": "Husqvarna Automower Options"
+            },
+            "home_init": {
+                "data": {
+                    "home_location": "GPS Coordinates of the charging station."
+                },
+                "description": "Set Home Location",
+                "title": "Husqvarna Automower Options"
+            },
+            "zone_edit": {"data": {
+                "name": "Zone Name",
+                "zone_coordinates": "Zone Coordinates lat,long;lat,long...",
+                "delete": "Delete this zone"
+                },
+                "description": "Configure Zone",
+                "title": "Husqvarna Automower Options"
+            },
+            "camera_init": {
                 "data": {
                     "enable_camera": "Enable Map Camera"
                 },
-                "description": "Enable Map Camera", 
+                "description": "Enable Map Camera",
                 "title": "Husqvarna Automower Options"
             },
-            "config": {
+            "camera_config": {
                 "data": {
                     "gps_top_left": "GPS Coordinates of the Top Left Image Corner",
                     "gps_bottom_right": "GPS Coordinates of the Bottom Right Image Corner",


### PR DESCRIPTION
Adds a location sensor that tracks which zone the mower is currently in.  Zones are created by defining at least 3 coordinates that define a bounding polygon. The sensor will return the first zone that the mowers location is inside the defined zone. 

This also adds the ability to define a home location, if the home location is defined the zone sensor will indicate home when the mower is charging or docked.

This sensor when combined with the History Stats integration will allow tracking the time the mower spends in each zone.

I have tested this on a dev build and my production python venv running core, on the dev build it installed and ran well, on the production build I had to install a missing dependency that was required by Shapely, likely just an old build, but would be good to confirm it works on more standard installations prior to merging.


![Screenshot 2022-06-28 220931](https://user-images.githubusercontent.com/18637008/176336160-302cdb0e-5803-4c62-a3db-cbca3ecef4c1.png)
![Screenshot 2022-06-28 221015](https://user-images.githubusercontent.com/18637008/176336162-d35ace3b-3baa-4ef5-b567-159516e55279.png)
![Screenshot 2022-06-28 221034](https://user-images.githubusercontent.com/18637008/176336163-98a796a0-919e-4bcf-aa1c-4779934ccf6e.png)
![Screenshot 2022-06-28 221102](https://user-images.githubusercontent.com/18637008/176336165-1bbfd0c2-45da-4970-9fd1-6120c18142c6.png)
![Screenshot 2022-06-28 221117](https://user-images.githubusercontent.com/18637008/176336166-3ddfbc99-1a73-445e-841b-2ff519ac7875.png)