### PR TITLE
remove log-in with password/username

### DIFF
--- a/custom_components/husqvarna_automower/__init__.py
+++ b/custom_components/husqvarna_automower/__init__.py
@@ -15,18 +15,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.typing import ConfigType
 
 from . import config_flow
-from .const import (
-    DOMAIN,
-    HUSQVARNA_URL,
-    OAUTH2_AUTHORIZE,
-    OAUTH2_TOKEN,
-    PLATFORMS,
-    STARTUP_MESSAGE,
-)
+from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN, PLATFORMS, STARTUP_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,36 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception:
         # If we haven't used the refresh_token (ie. been offline) for 10 days,
         # we need to login using username and password in the config flow again.
-        username = entry.data.get(CONF_USERNAME)
-        password = entry.data.get(CONF_PASSWORD)
-        if not (username and password):
-            raise ConfigEntryAuthFailed from Exception
-        if username and password:
-            get_token = aioautomower.GetAccessToken(
-                api_key,
-                username,
-                password,
-            )
-            access_token = await get_token.async_get_access_token()
-            _LOGGER.debug("access_token: %s", access_token)
-            hass.config_entries.async_update_entry(
-                entry,
-                data={
-                    CONF_TOKEN: access_token,
-                    CONF_USERNAME: username,
-                    CONF_PASSWORD: password,
-                },
-            )
-            try:
-                session = aioautomower.AutomowerSession(api_key, access_token)
-                await session.connect()
-            except Exception:
-                raise ConfigEntryAuthFailed from Exception
-
-    if "amc:api" not in access_token["scope"]:
-        raise ConfigEntryAuthFailed(
-            f"Your API-Key is not compatible to websocket, please renew it on {HUSQVARNA_URL}"
-        )
+        raise ConfigEntryAuthFailed from Exception
 
     hass.data[DOMAIN][entry.entry_id] = session
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/custom_components/husqvarna_automower/config_flow.py
+++ b/custom_components/husqvarna_automower/config_flow.py
@@ -7,18 +7,9 @@ import voluptuous as vol
 
 from aioautomower import GetAccessToken, GetMowerData, TokenError
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.const import (
-    ATTR_CREDENTIALS,
-    CONF_ACCESS_TOKEN,
-    CONF_API_KEY,
-    CONF_CLIENT_ID,
-    CONF_PASSWORD,
-    CONF_TOKEN,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_TOKEN
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.helpers.network import get_url
 
 from .const import (
     CONF_PROVIDER,
@@ -45,32 +36,6 @@ class HusqvarnaConfigFlowHandler(
     DOMAIN = DOMAIN
     VERSION = 2
 
-    async def _show_setup_form(self, errors):
-        """Show the setup form to the user."""
-
-        data_schema = {
-            vol.Required(CONF_API_KEY): vol.All(str, vol.Length(min=36, max=36)),
-            vol.Required(CONF_USERNAME): str,
-            vol.Required(CONF_PASSWORD): str,
-            vol.Required(ATTR_CREDENTIALS): bool,
-        }
-
-        return self.async_show_form(
-            step_id="password", data_schema=vol.Schema(data_schema), errors=errors
-        )
-
-    async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
-
-        _LOGGER.debug("URL: %s", get_url(self.hass))
-        return self.async_show_menu(
-            step_id="user",
-            menu_options=["oauth2", "password"],
-            description_placeholders={
-                "model": "Example model",
-            },
-        )
-
     async def async_step_oauth2(self, user_input=None):
         """Handle the config-flow for Authorization Code Grant."""
 
@@ -86,41 +51,6 @@ class HusqvarnaConfigFlowHandler(
         return await self.async_step_finish(
             self.hass.data[DOMAIN][CONF_CLIENT_ID], data
         )
-
-    async def async_step_password(self, user_input=None):
-        """Handle the config-flow with api-key, username and password."""
-
-        errors = {}
-        if user_input is None:
-            return await self._show_setup_form(errors)
-        try:
-            get_token = GetAccessToken(
-                user_input[CONF_API_KEY],
-                user_input[CONF_USERNAME],
-                user_input[CONF_PASSWORD],
-            )
-            access_token_raw = await get_token.async_get_access_token()
-        except (ClientConnectorError, TokenError):
-            # On 400 credentials could be wrong, or (Authentication API && Automower Connect API) are not connected.
-            errors["base"] = "auth"
-            return await self._show_setup_form(errors)
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "auth"
-            return await self._show_setup_form(errors)
-
-        await self.async_test_mower(user_input[CONF_API_KEY], access_token_raw)
-
-        unique_id = user_input[CONF_API_KEY]
-        data = {
-            CONF_TOKEN: access_token_raw,
-        }
-
-        if user_input[ATTR_CREDENTIALS] is True:
-            data[CONF_USERNAME] = user_input[CONF_USERNAME]
-            data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-
-        return await self.async_step_finish(unique_id, data)
 
     async def async_step_finish(self, unique_id, data):
         """Complete the config entries."""
@@ -139,7 +69,6 @@ class HusqvarnaConfigFlowHandler(
 
     async def async_test_mower(self, api_key, access_token_raw):
         """Test if mower data can be fetched with Rest, and also check websocket capabilities."""
-        errors = {}
         try:
             get_mower_data = GetMowerData(
                 api_key,
@@ -151,22 +80,15 @@ class HusqvarnaConfigFlowHandler(
             _LOGGER.debug("config: %s", mower_data)
         except (ClientConnectorError, ClientResponseError):
             if "amc:api" in access_token_raw["scope"]:
-                errors["base"] = "api_key"  ## Something's wrong with the key
                 _LOGGER.warning("Something's wrong with the API-key")
             else:
-                errors["base"] = "mower"  ## Automower Connect API not connected
                 _LOGGER.warning("Automower Connect API not connected")
-            return await self._show_setup_form(errors)
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-            return await self._show_setup_form(errors)
 
         if "amc:api" not in access_token_raw["scope"]:
             # If the API-Key is old
             _LOGGER.warning("The API-key is too old. Renew it")
-            errors["base"] = "api_key"
-            return await self._show_setup_form(errors)
 
     async def async_step_reauth(self, user_input=None):
         """Perform reauth upon an API authentication error."""
@@ -182,11 +104,6 @@ class HusqvarnaConfigFlowHandler(
             )
         _LOGGER.debug("user_input: %s", user_input)
         return await self.async_step_user()
-
-    @property
-    def logger(self) -> logging.Logger:
-        """Return logger."""
-        return logging.getLogger(__name__)
 
     @staticmethod
     @callback


### PR DESCRIPTION
Husqvarna is not documenting the log-in with username/password anymore on the website. I think they will stop this method soon. As it was already reported here: py-smart-gardena/hass-gardena-smart-system#115