### PR TITLE
Reorder mower state checks so the correct state is returned

### DIFF
--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -99,14 +99,14 @@ class HusqvarnaAutomowerStateMixin(object):
             "WAIT_POWER_UP",
         ]:
             return STATE_IDLE
-        if (mower_attributes["mower"]["state"] == "RESTRICTED") or (
-            mower_attributes["mower"]["activity"] in ["PARKED_IN_CS", "CHARGING"]
-        ):
-            return STATE_DOCKED
         if mower_attributes["mower"]["activity"] in ["MOWING", "LEAVING"]:
             return STATE_CLEANING
         if mower_attributes["mower"]["activity"] == "GOING_HOME":
             return STATE_RETURNING
+        if (mower_attributes["mower"]["state"] == "RESTRICTED") or (
+            mower_attributes["mower"]["activity"] in ["PARKED_IN_CS", "CHARGING"]
+        ):
+            return STATE_DOCKED
         if (
             mower_attributes["mower"]["state"]
             in [


### PR DESCRIPTION
If the `mower_attributes['state']` is `RESTRICTED`, the mower will be assumed to be in `STATE_DOCKED`, even if `mower_attributes['activity']` is `GOING_HOME`. In this case, the mower is actually going home, and not yet in the dock. This is fixed by reordering the checks.

Here is a _snip_ of debug info where I encountered the above:
```json
{
  "custom_components": {
    "husqvarna_automower": {
      "version": "2022.7.3",
      "requirements": [
        "aioautomower==2022.7.2",
        "geopy>=2.1.0",
        "numpy>=1.21.6",
        "Pillow>=9.1.1"
      ]
    },
  },
  "data": {
    "data_of_all_mowers": [
      {
        "type": "mower",
        "id": "20ea32ed-8e38-461b-8b0e-b5a48026dd19",
        "attributes": {
          "system": {
            "name": "Robota",
            "model": "HUSQVARNA AUTOMOWER® 415X",
            "serialNumber": "**REDACTED**"
          },
          "battery": {
            "batteryPercent": 56
          },
          "mower": {
            "mode": "MAIN_AREA",
            "activity": "GOING_HOME",
            "state": "RESTRICTED",
            "errorCode": 0,
            "errorCodeTimestamp": 0
          }
        }
      }
    ]
  }
}
```