### PR TITLE
Fix incorrect lines being drawn on the map to old positions

### DIFF
--- a/custom_components/husqvarna_automower/camera.py
+++ b/custom_components/husqvarna_automower/camera.py
@@ -123,7 +123,7 @@ class AutomowerCamera(HusqvarnaAutomowerStateMixin, Camera, AutomowerEntity):
         position_history = AutomowerEntity.get_mower_attributes(self)["positions"]
         location = (position_history[0]["latitude"], position_history[0]["longitude"])
         if len(position_history) == 1:
-            self._position_history += position_history
+            self._position_history = position_history + self._position_history
             position_history = self._position_history
         else:
             self._position_history = position_history


### PR DESCRIPTION
When we received a single position update, we were adding it to the end of the list
(where the oldest position update was), instead of the front.  This would
cause an incorrect path to be drawn from the current position to the last
position in the list.

So now we just add the new update to the front of the list to maintain the
correct order.