### PR TITLE
create entities only for available statistics

### DIFF
--- a/custom_components/husqvarna_automower/sensor.py
+++ b/custom_components/husqvarna_automower/sensor.py
@@ -222,15 +222,17 @@ async def async_setup_entry(
         for description in SENSOR_TYPES:
             try:
                 description.value_fn(session.data["data"][idx]["attributes"])
-                entity_list.append(AutomowerSensor(session, idx, description))
+                if description.key == "cuttingHeight":
+                    if any(
+                        ele
+                        in session.data["data"][idx]["attributes"]["system"]["model"]
+                        for ele in NO_SUPPORT_FOR_CHANGING_CUTTING_HEIGHT
+                    ):
+                        entity_list.append(AutomowerSensor(session, idx, description))
+                if description.key != "cuttingHeight":
+                    entity_list.append(AutomowerSensor(session, idx, description))
             except KeyError:
                 pass
-            if description.key == "cuttingHeight":
-                if any(
-                    ele in session.data["data"][idx]["attributes"]["system"]["model"]
-                    for ele in NO_SUPPORT_FOR_CHANGING_CUTTING_HEIGHT
-                ):
-                    entity_list.append(AutomowerSensor(session, idx, description))
 
     async_add_entities(entity_list)
 


### PR DESCRIPTION
show only available statistics #342
hint: If you have a mower, that doesn't support `cutting blade usage time` enable this sensor before updating to this version, otherwise the sensor never creates an unique_id and therefore it can't be deleted.