### PR TITLE
remove async_setup

### DIFF
--- a/custom_components/husqvarna_automower/__init__.py
+++ b/custom_components/husqvarna_automower/__init__.py
@@ -17,12 +17,6 @@ from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Husqvarna Automower component for Authorization Code Grant."""
-    if DOMAIN not in config:
-        return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:


### PR DESCRIPTION
This was only needed for the config with the configuration.yaml. If there is still an entry in the configuration.yaml for the client credentials, this will throw an error.