### PR TITLE
Add electronic cutting height support for old automower identifiers

### DIFF
--- a/custom_components/husqvarna_automower/const.py
+++ b/custom_components/husqvarna_automower/const.py
@@ -216,6 +216,8 @@ WEEKDAYS = (
 
 # Models that support electronic cutting height
 ELECTRONIC_CUTTING_HEIGHT_SUPPORT = [
+    "320",
+    "330",
     "405",
     "415",
     "420",


### PR DESCRIPTION
The 320 and 330 have the same hardware as 420/430 and could be updated to the same firmware.
Fix for #367