### PR TITLE
fix: SyntaxWarning: is with a literal. Did you mean ==?

### DIFF
--- a/custom_components/husqvarna_automower/sensor.py
+++ b/custom_components/husqvarna_automower/sensor.py
@@ -203,8 +203,8 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda data: data["battery"]["batteryPercent"],
         available_fn=lambda data: False
-        if (data["battery"]["batteryPercent"] is 0)
-        and (data["metadata"]["connected"] is False)
+        if (data["battery"]["batteryPercent"] == 0)
+        and (data["metadata"]["connected"] == False)
         else True,
     ),
     AutomowerSensorEntityDescription(


### PR DESCRIPTION
Solves:
/config/custom_components/husqvarna_automower/sensor.py:206: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if (data["battery"]["batteryPercent"] is 0)