### PR TITLE
Redact camera GPS coordinates from diagnostics

### DIFF
--- a/custom_components/husqvarna_automower/diagnostics.py
+++ b/custom_components/husqvarna_automower/diagnostics.py
@@ -6,12 +6,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_REFRESH_TOKEN, DOMAIN, POSITIONS
+from .const import CONF_REFRESH_TOKEN, DOMAIN, POSITIONS, GPS_TOP_LEFT, GPS_BOTTOM_RIGHT
 
 TO_REDACT = {
     CONF_ACCESS_TOKEN,
     CONF_REFRESH_TOKEN,
     POSITIONS,
+    GPS_TOP_LEFT,
+    GPS_BOTTOM_RIGHT,
 }
 
 


### PR DESCRIPTION
When downloading integration diagnostics, the `data.data_of_all_mowers.attributes.positions` key is redacted, however, `data.options.gps_{top_left,bottom_right}` (used for the camera map) are not redacted and will thus reveal the installation address. I noticed this in https://github.com/Thomas55555/husqvarna_automower/issues/455#issuecomment-1556285711 @Marc1200

This PR redacts `GPS_TOP_LEFT` and `GPS_BOTTOM_RIGHT` from diagnostics. It has been tested and is working as expected.