### PR TITLE
Extend support for translations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "core"]
-	path = core
-	url = https://github.com/home-assistant/core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core"]
+	path = core
+	url = https://github.com/home-assistant/core.git

--- a/custom_components/husqvarna_automower/binary_sensor.py
+++ b/custom_components/husqvarna_automower/binary_sensor.py
@@ -39,7 +39,7 @@ class AutomowerBatteryChargingBinarySensor(BinarySensorEntity, AutomowerEntity):
 
     _attr_entity_registry_enabled_default = False
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
-    _attr_name = "Battery charging"
+    _attr_translation_key = "battery_charging"
 
     def __init__(self, session, idx):
         """Initialize AutomowerBatteryChargingBinarySensor."""
@@ -60,7 +60,7 @@ class AutomowerLeavingDockBinarySensor(BinarySensorEntity, AutomowerEntity):
     """Defining the AutomowerProblemSensor Entity."""
 
     _attr_entity_registry_enabled_default = False
-    _attr_name = "Leaving dock"
+    _attr_translation_key = "leaving_dock"
 
     def __init__(self, session, idx) -> None:
         """Initialize AutomowerLeavingDockBinarySensor."""
@@ -82,7 +82,7 @@ class AutomowerErrorBinarySensor(BinarySensorEntity, AutomowerEntity):
 
     _attr_entity_registry_enabled_default: bool = False
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PROBLEM
-    _attr_name = "Error"
+    _attr_translation_key = "error"
 
     def __init__(self, session, idx):
         """Initialize AutomowerErrorBinarySensor."""

--- a/custom_components/husqvarna_automower/camera.py
+++ b/custom_components/husqvarna_automower/camera.py
@@ -48,7 +48,7 @@ class AutomowerCamera(HusqvarnaAutomowerStateMixin, Camera, AutomowerEntity):
 
     _attr_frame_interval: float = 300
     _attr_name = "Map"
-    _attr_translation_key = "quirk"
+    _attr_translation_key = "mower"
 
     def __init__(self, session, idx, entry) -> None:
         """Initialize AutomowerCamera."""

--- a/custom_components/husqvarna_automower/camera.py
+++ b/custom_components/husqvarna_automower/camera.py
@@ -8,7 +8,7 @@ from typing import Optional
 from PIL import Image, ImageDraw
 import numpy as np
 
-from homeassistant.components.camera import SUPPORT_ON_OFF, Camera
+from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,8 +47,7 @@ class AutomowerCamera(HusqvarnaAutomowerStateMixin, Camera, AutomowerEntity):
     """Representation of the AutomowerCamera element."""
 
     _attr_frame_interval: float = 300
-    _attr_name = "Map"
-    _attr_translation_key = "mower"
+    _attr_translation_key = "mower_cam"
 
     def __init__(self, session, idx, entry) -> None:
         """Initialize AutomowerCamera."""
@@ -88,9 +87,10 @@ class AutomowerCamera(HusqvarnaAutomowerStateMixin, Camera, AutomowerEntity):
             self.top_left_coord = (top_left_lat, top_left_lon)
             self.bottom_right_coord = (bottom_right_lat, bottom_right_lon)
 
+    @property
     def model(self) -> str:
         """Return the mower model."""
-        return self.model
+        return self.model_name
 
     async def async_camera_image(
         self, width: Optional[int] = None, height: Optional[int] = None
@@ -118,7 +118,7 @@ class AutomowerCamera(HusqvarnaAutomowerStateMixin, Camera, AutomowerEntity):
     @property
     def supported_features(self) -> int:
         """Show supported features."""
-        return SUPPORT_ON_OFF
+        return CameraEntityFeature.ON_OFF
 
     def _generate_image(self, data: dict):
         position_history = AutomowerEntity.get_mower_attributes(self)["positions"]

--- a/custom_components/husqvarna_automower/const.py
+++ b/custom_components/husqvarna_automower/const.py
@@ -202,7 +202,7 @@ ERRORCODES = {
 }
 
 # Headlight modes
-HEADLIGHTMODES = ["ALWAYS_ON", "ALWAYS_OFF", "EVENING_ONLY", "EVENING_AND_NIGHT"]
+HEADLIGHTMODES = ["always_on", "always_off", "evening_only", "evening_and_night"]
 
 # Weekdays
 WEEKDAYS = (

--- a/custom_components/husqvarna_automower/entity.py
+++ b/custom_components/husqvarna_automower/entity.py
@@ -28,7 +28,7 @@ class AutomowerEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
         mower_attributes = self.get_mower_attributes()
         self.mower_id = self.mower["id"]
         self.mower_name = mower_attributes["system"]["name"]
-        self.model = mower_attributes["system"]["model"]
+        self.model_name = mower_attributes["system"]["model"]
 
         self._available = self.get_mower_attributes()["metadata"]["connected"]
 
@@ -66,7 +66,7 @@ class AutomowerEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
             identifiers={(DOMAIN, self.mower_id)},
             name=self.mower_name,
             manufacturer="Husqvarna",
-            model=self.model,
+            model=self.model_name,
             configuration_url=HUSQVARNA_URL,
             suggested_area="Garden",
         )

--- a/custom_components/husqvarna_automower/number.py
+++ b/custom_components/husqvarna_automower/number.py
@@ -43,14 +43,14 @@ async def async_setup_entry(
 NUMBER_SENSOR_TYPES: tuple[NumberEntityDescription, ...] = (
     NumberEntityDescription(
         key="Park",
-        name="Park for",
+        translation_key="park_for",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
         native_unit_of_measurement=TIME_MINUTES,
     ),
     NumberEntityDescription(
         key="Start",
-        name="Mow for",
+        translation_key="mow_for",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
         native_unit_of_measurement=TIME_MINUTES,
@@ -65,7 +65,7 @@ class AutomowerNumber(NumberEntity, AutomowerEntity):
     _attr_icon = "mdi:grass"
     _attr_native_min_value = 1
     _attr_native_max_value = 9
-    _attr_name = "Cutting height"
+    _attr_translation_key = "cutting_height"
 
     def __init__(self, session, idx):
         """Initialize AutomowerNumber."""
@@ -113,7 +113,6 @@ class AutomowerParkStartNumberEntity(NumberEntity, AutomowerEntity):
         super().__init__(session, idx)
         self.description = description
         self.entity_description = description
-        self._attr_name = description.name
         self._attr_unique_id = f"{self.mower_id}_{description.key}"
 
     @property

--- a/custom_components/husqvarna_automower/select.py
+++ b/custom_components/husqvarna_automower/select.py
@@ -36,7 +36,7 @@ class AutomowerSelect(SelectEntity, AutomowerEntity):
     _attr_options = HEADLIGHTMODES
     _attr_icon = "mdi:car-light-high"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_name = "Headlight mode"
+    _attr_translation_key = "headlight_mode"
 
     def __init__(self, session, idx):
         """Initialize AutomowerSelect."""
@@ -53,7 +53,7 @@ class AutomowerSelect(SelectEntity, AutomowerEntity):
     def current_option(self) -> str:
         """Return a the current option for the entity."""
         mower_attributes = AutomowerEntity.get_mower_attributes(self)
-        return mower_attributes["headlight"]["mode"]
+        return mower_attributes["headlight"]["mode"].lower()
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -61,7 +61,7 @@ class AutomowerSelect(SelectEntity, AutomowerEntity):
         string = {
             "data": {
                 "type": "settings",
-                "attributes": {"headlight": {"mode": option}},
+                "attributes": {"headlight": {"mode": option.upper()}},
             }
         }
         payload = json.dumps(string)

--- a/custom_components/husqvarna_automower/sensor.py
+++ b/custom_components/husqvarna_automower/sensor.py
@@ -88,7 +88,7 @@ def problem_list() -> list:
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     AutomowerSensorEntityDescription(
         key="cuttingBladeUsageTime",
-        name="Cutting blade usage time",
+        translation_key="cutting_blade_usage_time",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -100,7 +100,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalChargingTime",
-        name="Total charging time",
+        translation_key="total_charging_time",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -112,7 +112,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalCuttingTime",
-        name="Total cutting time",
+        translation_key="total_cutting_time",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -124,7 +124,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalRunningTime",
-        name="Total running time",
+        translation_key="total_running_time",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -136,7 +136,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalSearchingTime",
-        name="Total searching time",
+        translation_key="total_searching_time",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -148,7 +148,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="numberOfChargingCycles",
-        name="Number of charging cycles",
+        translation_key="number_of_charging_cycles",
         icon="mdi:battery-sync-outline",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -158,7 +158,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="numberOfCollisions",
-        name="Number of collisions",
+        translation_key="number_of_collisions",
         icon="mdi:counter",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -168,7 +168,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalSearchingTime_percentage",
-        name="Searching time percent",
+        translation_key="searching_time_percent",
         icon="mdi:percent",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -182,7 +182,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="totalCuttingTime_percentage",
-        name="Cutting time percent",
+        translation_key="cutting_time_percent",
         icon="mdi:percent",
         entity_registry_enabled_default=True,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -196,7 +196,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="battery_level",
-        name="Battery level",
+        translation_key="battery_level",
         entity_registry_enabled_default=True,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
@@ -209,7 +209,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="next_start",
-        name="Next start",
+        translation_key="next_start",
         entity_registry_enabled_default=True,
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: AutomowerEntity.datetime_object(
@@ -219,21 +219,19 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="mode",
-        name="Mode",
+        translation_key="mode_list",
         entity_registry_enabled_default=False,
         device_class=SensorDeviceClass.ENUM,
         options=["main_area", "secondary_area", "home", "demo", "unknown"],
-        translation_key="mode_list",
         value_fn=lambda data: data["mower"]["mode"].lower(),
         available_fn=lambda data: True,
     ),
     AutomowerSensorEntityDescription(
         key="problem_sensor",
-        name="Problem Sensor",
+        translation_key="problem_list",
         entity_registry_enabled_default=False,
         device_class=SensorDeviceClass.ENUM,
         options=problem_list(),
-        translation_key="problem_list",
         value_fn=lambda data: None
         if get_problem(data) is None
         else get_problem(data).lower(),
@@ -241,7 +239,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
     AutomowerSensorEntityDescription(
         key="cuttingHeight",
-        name="Cutting height",
+        translation_key="cutting_height",
         entity_registry_enabled_default=True,
         icon="mdi:grass",
         state_class=SensorStateClass.MEASUREMENT,
@@ -297,7 +295,6 @@ class AutomowerSensor(SensorEntity, AutomowerEntity):
         """Set up AutomowerSensors."""
         super().__init__(session, idx)
         self.entity_description = description
-        self._attr_name = description.name
         self._attr_unique_id = f"{self.mower_id}_{description.key}"
 
     @property

--- a/custom_components/husqvarna_automower/translations/da.json
+++ b/custom_components/husqvarna_automower/translations/da.json
@@ -27,7 +27,6 @@
                     "gps_bottom_right": "GPS koordinater for det nederste højre hjørne af billedet",
                     "mower_img_path": "Filsti til billede af plæneklipper",
                     "map_img_path": "Filsti til billede af kortet"
-
                 },
                 "description": "Kamera indstillinger",
                 "title": "Husqvarna Automower indstillinger"
@@ -72,14 +71,14 @@
             }
         },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Slår græs"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Slår græs"
                 }

--- a/custom_components/husqvarna_automower/translations/de.json
+++ b/custom_components/husqvarna_automower/translations/de.json
@@ -17,48 +17,48 @@
             "can_reach_server": "Husqvarna Token Server erreichbar"
         }
     },
-	"entity": {
-		"sensor": {
-			"problem_list": {
-				"state": {
-				    "off": "Aus",
-				    "unknown": "Unbekannt",
-				    "stopped": "Angehalten",
-				    "stopped_in_garden": "Im Garten angehalten",
-				    "not_applicable": "Nicht anwendbar",
-				    "none": "Nichts",
-				    "week_schedule": "Wochenplaner",
-				    "park_override": "Parken erzwungen",
-				    "sensor": "Wetter timer",
-				    "daily_limit": "Tägliches limit",
-				    "fota": "FOTA",
-				    "frost": "Frost",
-				    "parked_until_further_notice": "Bis auf weiters geparkt"
-				}
-			},
-			"mode_list":{
-				"state": {
-				    "main_area": "Hauptbereich",
-				    "secondary_area": "Zweitbereich",
-				    "home": "In der Ladestation",
-				    "demo": "Demo",
-				    "unknown": "Unbekannt"
-				}
-			}
-		},
+    "entity": {
+        "sensor": {
+            "problem_list": {
+                "state": {
+                    "off": "Aus",
+                    "unknown": "Unbekannt",
+                    "stopped": "Angehalten",
+                    "stopped_in_garden": "Im Garten angehalten",
+                    "not_applicable": "Nicht anwendbar",
+                    "none": "Nichts",
+                    "week_schedule": "Wochenplaner",
+                    "park_override": "Parken erzwungen",
+                    "sensor": "Wetter timer",
+                    "daily_limit": "Tägliches limit",
+                    "fota": "FOTA",
+                    "frost": "Frost",
+                    "parked_until_further_notice": "Bis auf weiters geparkt"
+                }
+            },
+            "mode_list": {
+                "state": {
+                    "main_area": "Hauptbereich",
+                    "secondary_area": "Zweitbereich",
+                    "home": "In der Ladestation",
+                    "demo": "Demo",
+                    "unknown": "Unbekannt"
+                }
+            }
+        },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Mähen"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Mähen"
                 }
             }
         }
-	}
+    }
 }

--- a/custom_components/husqvarna_automower/translations/de.json
+++ b/custom_components/husqvarna_automower/translations/de.json
@@ -18,6 +18,17 @@
         }
     },
     "entity": {
+        "select": {
+            "headlight_mode": {
+                "name": "Schweinwerfer Zeitplan",
+                "state": {
+                    "always_on": "Immer an",
+                    "always_off": "Immer aus",
+                    "evening_only": "Nur abends",
+                    "evening_and_night": "Abends und nachts"
+                }
+            }
+        },
         "sensor": {
             "problem_list": {
                 "state": {

--- a/custom_components/husqvarna_automower/translations/en.json
+++ b/custom_components/husqvarna_automower/translations/en.json
@@ -146,13 +146,52 @@
             "mower": {
                 "state": {
                     "cleaning": "Mowing"
+                },
+                "state_attributes": {
+                    "status": {
+                        "name": "Status",
+                        "state": {
+                            "cleaning": "Mowing",
+                            "off": "Off",
+                            "unknown": "Unknown",
+                            "stopped": "Stopped",
+                            "not_applicable": "Not applicable",
+                            "paused": "Paused",
+                            "going_to_charging_station": "Going to charging station",
+                            "leaving_charging_station": "Leaving charging station",
+                            "parked": "Parked",
+                            "park_override": "Park override",
+                            "daily_limit": "Daily limit",
+                            "fota": "Fota",
+                            "updating": "Updating",
+                            "powering_up": "Powering up",
+                            "weather_timer": "Weather timer",
+                            "parked_until_further_notice": "Parked until further notice"
+                        }
+                    },
+                    "action": {
+                        "name": "Action",
+                        "state": {
+                            "force_mow": "Force mowing",
+                            "not_active": "Not active",
+                            "unknown": "Unknown"
+                        }
+                    }
                 }
             }
         },
         "camera": {
-            "mower": {
+            "mower_cam": {
+                "name": "Map",
                 "state": {
-                    "cleaning": "Mowing"
+                    "cleaning": "Mowing",
+                    "docked": "Docked",
+                    "error": "Error",
+                    "idle": "Idle",
+                    "off": "Off",
+                    "on": "On",
+                    "paused": "Paused",
+                    "returning": "Returning to dock"
                 }
             }
         }

--- a/custom_components/husqvarna_automower/translations/en.json
+++ b/custom_components/husqvarna_automower/translations/en.json
@@ -43,8 +43,78 @@
         "description": "Create an account on [Husqvarna developers portal]({oauth_creds_url}). Connect The Authentication API and Automower Connect API. As redirect-URI set https://my.home-assistant.io/redirect/oauth. If you haven't set up My HomeAssistant already. Enter this URL for your instance {redirect_uri}"
     },
     "entity": {
+        "binary_sensor": {
+            "battery_charging": {
+                "name": "Battery charging"
+            },
+            "leaving_dock": {
+                "name": "Leaving dock"
+            },
+            "error": {
+                "name": "Error"
+            }
+        },
+        "number": {
+            "cutting_height": {
+                "name": "Cutting height"
+            },
+            "mow_for": {
+                "name": "Mow for"
+            },
+            "park_for": {
+                "name": "Park for"
+            }
+        },
+        "select": {
+            "headlight_mode": {
+                "name": "Headlight mode",
+                "state": {
+                    "always_on": "Always on",
+                    "always_off": "Always Off",
+                    "evening_only": "Evening only",
+                    "evening_and_night": "Evening and night"
+                }
+            }
+        },
         "sensor": {
+            "cutting_height": {
+                "name": "Cutting height"
+            },
+            "number_of_charging_cycles": {
+                "name": "Number of charging cycles"
+            },
+            "number_of_collisions": {
+                "name": "Number of collisions"
+            },
+            "cutting_blade_usage_time": {
+                "name": "Cutting blade usage time"
+            },
+            "total_charging_time": {
+                "name": "Total charging time"
+            },
+            "total_cutting_time": {
+                "name": "Total cutting time"
+            },
+            "total_running_time": {
+                "name": "Total running time"
+            },
+            "total_searching_time": {
+                "name": "Total searching time"
+            },
+            "searching_time_percent": {
+                "name": "Searching time percent"
+            },
+            "cutting_time_percent": {
+                "name": "Cutting time percent"
+            },
+            "battery_level": {
+                "name": "Battery level"
+            },
+            "next_start": {
+                "name": "Next start"
+            },
             "problem_list": {
+                "name": "Problem sensor",
                 "state": {
                     "off": "Off",
                     "unknown": "Unknown",
@@ -62,6 +132,7 @@
                 }
             },
             "mode_list": {
+                "name": "Mode",
                 "state": {
                     "main_area": "Main area",
                     "secondary_area": "Secondary area",
@@ -72,24 +143,17 @@
             }
         },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Mowing"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
-					"cleaning": "Mowing",
-					"docked": "Docked",
-					"error": "Error",
-					"idle": "[%key:common::state::idle%]",
-					"off": "[%key:common::state::off%]",
-					"on": "[%key:common::state::on%]",
-					"paused": "[%key:common::state::paused%]",
-					"returning": "Returning to dock"
-				}
+                    "cleaning": "Mowing"
+                }
             }
         }
     },

--- a/custom_components/husqvarna_automower/translations/es.json
+++ b/custom_components/husqvarna_automower/translations/es.json
@@ -27,7 +27,6 @@
                     "gps_bottom_right": "Coordenadas GPS Coordinates de la esquina inferior derecha de la imagen",
                     "mower_img_path": "Ruta a la localizacion de la imagen del cortacesped",
                     "map_img_path": "Ruta a la localizacion de la imagen del mapa"
-
                 },
                 "description": "Ajustes de la cámara",
                 "title": "Opciones de Husqvarna Automower"
@@ -60,7 +59,7 @@
                     "frost": "Hielo"
                 }
             },
-            "mode_list":{
+            "mode_list": {
                 "state": {
                     "main_area": "Área principal",
                     "secondary_area": "Area secundaria",
@@ -71,14 +70,14 @@
             }
         },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Segando"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Segando"
                 }

--- a/custom_components/husqvarna_automower/translations/et.json
+++ b/custom_components/husqvarna_automower/translations/et.json
@@ -42,57 +42,57 @@
     "application_credentials": {
         "description": "Loo konto [Husqvarna developers portal]({oauth_creds_url}). Ühenda Authentication API ja Automower Connect API. Sea ümbersuunamise URI https://my.home-assistant.io/redirect/oauth. Kui sa pole veel seadistanud My HomeAssistant asukohta, sisesta see URL oma asukohaks {redirect_uri}"
     },
-	"entity": {
-		"sensor": {
-			"problem_list": {
-				"state": {
-					"off": "Väljas",
-					"unknown": "Teadmata",
-					"stopped": "Peatunud",
-					"stopped_in_garden": "Peatunud aias",
-					"not_applicable": "Pole kohalduv",
-					"none": "Puudub",
-					"week_schedule": "Nädala ajakava",
-					"park_override": "Parkimise tühistamine",
-					"sensor": "Ilmataimer",
-					"daily_limit": "Päevane limiit",
-					"fota": "Püsivara uuendamine",
-					"frost": "Härmatis",
+    "entity": {
+        "sensor": {
+            "problem_list": {
+                "state": {
+                    "off": "Väljas",
+                    "unknown": "Teadmata",
+                    "stopped": "Peatunud",
+                    "stopped_in_garden": "Peatunud aias",
+                    "not_applicable": "Pole kohalduv",
+                    "none": "Puudub",
+                    "week_schedule": "Nädala ajakava",
+                    "park_override": "Parkimise tühistamine",
+                    "sensor": "Ilmataimer",
+                    "daily_limit": "Päevane limiit",
+                    "fota": "Püsivara uuendamine",
+                    "frost": "Härmatis",
                     "parked_until_further_notice": "Pargitud kuni edasise korralduseni"
-				}
-			},
-			"mode_list": {
-				"state": {
+                }
+            },
+            "mode_list": {
+                "state": {
                     "main_area": "Peamine niiduala",
                     "secondary_area": "Teisene niiduala",
                     "home": "Laadimisjaam",
                     "demo": "Demo",
                     "unknown": "Teadmata"
                 }
-			}
-		},
+            }
+        },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Niidab"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Niidab",
-					"docked": "Dokitud",
-					"error": "Viga",
-					"idle": "[%key:common::state::idle%]",
-					"off": "[%key:common::state::off%]",
-					"on": "[%key:common::state::on%]",
-					"paused": "[%key:common::state::paused%]",
-					"returning": "Läheb laadimisjaama"
+                    "docked": "Dokitud",
+                    "error": "Viga",
+                    "idle": "[%key:common::state::idle%]",
+                    "off": "[%key:common::state::off%]",
+                    "on": "[%key:common::state::on%]",
+                    "paused": "[%key:common::state::paused%]",
+                    "returning": "Läheb laadimisjaama"
                 }
             }
         }
-	},
+    },
     "issues": {
         "wrong_scope": {
             "title": "Sinu juurdepääsutõendi kehtivusala on vale",

--- a/custom_components/husqvarna_automower/translations/fr.json
+++ b/custom_components/husqvarna_automower/translations/fr.json
@@ -18,14 +18,14 @@
     },
     "entity": {
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Tonte"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Tonte"
                 }

--- a/custom_components/husqvarna_automower/translations/no.json
+++ b/custom_components/husqvarna_automower/translations/no.json
@@ -27,7 +27,6 @@
                     "gps_bottom_right": "GPS koordinater for det nedre høyre hjørne av bildet",
                     "mower_img_path": "Filsti til bilde af robotklipper",
                     "map_img_path": "Filsti til bilde af kartet"
-
                 },
                 "description": "Kamera instillinger",
                 "title": "Husqvarna Automower instillinger"
@@ -44,14 +43,14 @@
     },
     "entity": {
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Klipper"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Klipper"
                 }

--- a/custom_components/husqvarna_automower/translations/sv.json
+++ b/custom_components/husqvarna_automower/translations/sv.json
@@ -122,7 +122,7 @@
                     "not_applicable": "Ej tillämpligt",
                     "none": "Inget",
                     "week_schedule": "Veckoschema",
-                    "park_override": "Perkering åsidosatt",
+                    "park_override": "Parkering åsidosatt",
                     "sensor": "Vädertimer",
                     "daily_limit": "Daglig begränsning",
                     "fota": "Fota",

--- a/custom_components/husqvarna_automower/translations/sv.json
+++ b/custom_components/husqvarna_automower/translations/sv.json
@@ -145,15 +145,60 @@
             "mower": {
                 "state": {
                     "cleaning": "Klipper"
+                },
+                "state_attributes": {
+                    "status": {
+                        "name": "Status",
+                        "state": {
+                            "cleaning": "Klipper",
+                            "off": "Från",
+                            "unknown": "Okänd",
+                            "stopped": "Stoppad",
+                            "not_applicable": "Ej tillämpligt",
+                            "paused": "Pausad",
+                            "going_to_charging_station": "På väg till laddningsstation",
+                            "leaving_charging_station": "Lämnar laddningsstation",
+                            "parked": "Parkerad",
+                            "park_override": "Parkering åsidosatt",
+                            "daily_limit": "Daglig begränsning",
+                            "fota": "Fota",
+                            "updating": "Updaterar",
+                            "powering_up": "Startar",
+                            "weather_timer": "Vädertimer",
+                            "parked_until_further_notice": "Parkerad tills vidare"
+                        }
+                    },
+                    "action": {
+                        "name": "Aktion",
+                        "state": {
+                            "force_mow": "Forcera klippning",
+                            "not_active": "Inaktiv",
+                            "unknown": "Okänd"
+                        }
+                    }
                 }
             }
         },
         "camera": {
-            "mower": {
+            "mower_cam": {
+                "name": "Karta",
                 "state": {
-                    "cleaning": "Klipper"
+                    "cleaning": "Klipper",
+                    "docked": "Dockad",
+                    "error": "Fel",
+                    "idle": "Inaktiv",
+                    "off": "Från",
+                    "on": "Till",
+                    "paused": "Pausad",
+                    "returning": "Återvänder till dockan"
                 }
             }
+        }
+    },
+    "issues": {
+        "wrong_scope": {
+            "title": "Felaktigt scope för token",
+            "description": "Ändra scope för att kunna använda websocket och omedelbara uppdateringar av status för klipparen. Läs mer här: https://developer.husqvarnagroup.cloud/apis/automower-connect-api#websocket"
         }
     }
 }

--- a/custom_components/husqvarna_automower/translations/sv.json
+++ b/custom_components/husqvarna_automower/translations/sv.json
@@ -86,7 +86,7 @@
                 "name": "Antal kollisioner"
             },
             "cutting_blade_usage_time": {
-                "name": "Knivblad avnända"
+                "name": "Knivblad använda"
             },
             "total_charging_time": {
                 "name": "Total laddningstid"

--- a/custom_components/husqvarna_automower/translations/sv.json
+++ b/custom_components/husqvarna_automower/translations/sv.json
@@ -27,7 +27,6 @@
                     "gps_bottom_right": "GPS-koordinater för det nedre högra bildhörnet",
                     "mower_img_path": "Sökväg till bild på gräsklipparen",
                     "map_img_path": "Sökväg till kartbilden"
-
                 },
                 "description": "Kamerainställningar",
                 "title": "Husqvarna Automower-inställningar"
@@ -40,18 +39,117 @@
         }
     },
     "application_credentials": {
-      "description": "Skapa ett konto på [Husqvarna developers portal]({oauth_creds_url}). Anslut Authentication API and Automower Connect API. Som redirect-URI anges https://my.home-assistant.io/redirect/oauth. Om du inte har konfigurerat My HomeAssistant, ange istället denna URL: {redirect_uri}"
+        "description": "Skapa ett konto på [Husqvarna developers portal]({oauth_creds_url}). Anslut Authentication API and Automower Connect API. Som redirect-URI anges https://my.home-assistant.io/redirect/oauth. Om du inte har konfigurerat My HomeAssistant, ange istället denna URL: {redirect_uri}"
     },
     "entity": {
+        "binary_sensor": {
+            "battery_charging": {
+                "name": "Batteriladdning"
+            },
+            "leaving_dock": {
+                "name": "Lämnar laddningsstationen"
+            },
+            "error": {
+                "name": "Fel"
+            }
+        },
+        "number": {
+            "cutting_height": {
+                "name": "Klipphöjd"
+            },
+            "mow_for": {
+                "name": "Klipp i"
+            },
+            "park_for": {
+                "name": "Parkera i"
+            }
+        },
+        "select": {
+            "headlight_mode": {
+                "name": "Strålkastare",
+                "state": {
+                    "always_on": "Alltid på",
+                    "always_off": "Alltid av",
+                    "evening_only": "Endast kväll",
+                    "evening_and_night": "Kväll och natt"
+                }
+            }
+        },
+        "sensor": {
+            "cutting_height": {
+                "name": "Klipphöjd"
+            },
+            "number_of_charging_cycles": {
+                "name": "Antal laddningscykler"
+            },
+            "number_of_collisions": {
+                "name": "Antal kollisioner"
+            },
+            "cutting_blade_usage_time": {
+                "name": "Knivblad avnända"
+            },
+            "total_charging_time": {
+                "name": "Total laddningstid"
+            },
+            "total_cutting_time": {
+                "name": "Total klipptid"
+            },
+            "total_running_time": {
+                "name": "Total drifttid"
+            },
+            "total_searching_time": {
+                "name": "Total söktid"
+            },
+            "searching_time_percent": {
+                "name": "Söktid andel"
+            },
+            "cutting_time_percent": {
+                "name": "Klipptid andel"
+            },
+            "battery_level": {
+                "name": "Batterinivå"
+            },
+            "next_start": {
+                "name": "Nästa start"
+            },
+            "problem_list": {
+                "name": "Problem",
+                "state": {
+                    "off": "Från",
+                    "unknown": "Okänt",
+                    "stopped": "Stoppad",
+                    "stopped_in_garden": "Stoppad i trädgårdenn",
+                    "not_applicable": "Ej tillämpligt",
+                    "none": "Inget",
+                    "week_schedule": "Veckoschema",
+                    "park_override": "Perkering åsidosatt",
+                    "sensor": "Vädertimer",
+                    "daily_limit": "Daglig begränsning",
+                    "fota": "Fota",
+                    "frost": "Frost",
+                    "parked_until_further_notice": "Parkerad tills vidare"
+                }
+            },
+            "mode_list": {
+                "name": "Driftläge",
+                "state": {
+                    "main_area": "Huvudyta",
+                    "secondary_area": "Sekundär yta",
+                    "home": "Hem",
+                    "demo": "Demo",
+                    "unknown": "Okänt"
+                }
+            }
+        },
         "vacuum": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Klipper"
                 }
             }
         },
         "camera": {
-            "quirk": {
+            "mower": {
                 "state": {
                     "cleaning": "Klipper"
                 }

--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -140,10 +140,9 @@ class HusqvarnaAutomowerEntity(
 ):
     """Defining each mower Entity."""
 
-    _attr_device_class = f"{DOMAIN}__mower"
     _attr_icon = "mdi:robot-mower"
     _attr_supported_features = SUPPORT_STATE_SERVICES
-    _attr_translation_key = "quirk"
+    _attr_translation_key = "mower"
 
     def __init__(self, session, idx):
         """Set up HusqvarnaAutomowerEntity."""

--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -223,7 +223,7 @@ class HusqvarnaAutomowerEntity(
             "ERROR_AT_POWER_UP",
         ]:
             errorcode = mower_attributes["mower"]["errorCode"]
-            return ERRORCODES.get(errorcode, f'error_{errorcode}')
+            return ERRORCODES.get(errorcode, f"error_{errorcode}")
         return None
 
     @property

--- a/custom_components/husqvarna_automower/vacuum.py
+++ b/custom_components/husqvarna_automower/vacuum.py
@@ -131,7 +131,8 @@ class HusqvarnaAutomowerStateMixin(object):
         """Define an error message if the vacuum is in STATE_ERROR."""
         if self.state == STATE_ERROR:
             mower_attributes = AutomowerEntity.get_mower_attributes(self)
-            return ERRORCODES.get(mower_attributes["mower"]["errorCode"])
+            errorcode = mower_attributes["mower"]["errorCode"]
+            return ERRORCODES.get(errorcode, f"error_{errorcode}")
         return None
 
 
@@ -175,62 +176,65 @@ class HusqvarnaAutomowerEntity(
             )
             next_start_short = next_start_dt_obj.strftime(", next start: %a %H:%M")
         if mower_attributes["mower"]["state"] == "UNKNOWN":
-            return "Unknown"
+            return "unknown"
         if mower_attributes["mower"]["state"] == "NOT_APPLICABLE":
-            return "Not applicable"
+            return "not_applicable"
         if mower_attributes["mower"]["state"] == "PAUSED":
-            return "Paused"
+            return "paused"
         if mower_attributes["mower"]["state"] == "IN_OPERATION":
             if mower_attributes["mower"]["activity"] == "UNKNOWN":
-                return "Unknown"
+                return "unknown"
             if mower_attributes["mower"]["activity"] == "NOT_APPLICABLE":
-                return "Not applicable"
+                return "not_applicable"
             if mower_attributes["mower"]["activity"] == "MOWING":
-                return "Mowing"
+                return "cleaning"
             if mower_attributes["mower"]["activity"] == "GOING_HOME":
-                return "Going to charging station"
+                return "going to charging station"
             if mower_attributes["mower"]["activity"] == "CHARGING":
                 return f"Charging{next_start_short}"
             if mower_attributes["mower"]["activity"] == "LEAVING":
-                return "Leaving charging station"
+                return "leaving_charging_station"
             if mower_attributes["mower"]["activity"] == "PARKED_IN_CS":
-                return "Parked"
+                return "parked"
             if mower_attributes["mower"]["activity"] == "STOPPED_IN_GARDEN":
-                return "Stopped"
+                return "stopped"
         if mower_attributes["mower"]["state"] == "WAIT_UPDATING":
-            return "Updating"
+            return "updating"
         if mower_attributes["mower"]["state"] == "WAIT_POWER_UP":
-            return "Powering up"
+            return "powering_up"
         if mower_attributes["mower"]["state"] == "RESTRICTED":
             if mower_attributes["planner"]["restrictedReason"] == "WEEK_SCHEDULE":
                 return f"Schedule{next_start_short}"
             if mower_attributes["planner"]["restrictedReason"] == "PARK_OVERRIDE":
-                return "Park override"
+                return "park_override"
             if mower_attributes["planner"]["restrictedReason"] == "SENSOR":
-                return "Weather timer"
+                return "weather_timer"
             if mower_attributes["planner"]["restrictedReason"] == "DAILY_LIMIT":
-                return "Daily limit"
+                return "daily_limit"
             if mower_attributes["planner"]["restrictedReason"] == "NOT_APPLICABLE":
-                return "Parked until further notice"
+                return "parked_until_further_notice"
         if mower_attributes["mower"]["state"] == "OFF":
-            return "Off"
+            return "off"
         if mower_attributes["mower"]["state"] == "STOPPED":
-            return "Stopped"
+            return "stopped"
         if mower_attributes["mower"]["state"] in [
             "ERROR",
             "FATAL_ERROR",
             "ERROR_AT_POWER_UP",
         ]:
-            return ERRORCODES.get(mower_attributes["mower"]["errorCode"])
+            errorcode = mower_attributes["mower"]["errorCode"]
+            return ERRORCODES.get(errorcode, f'error_{errorcode}')
         return None
 
     @property
     def extra_state_attributes(self) -> dict:
         """Return the specific state attributes of this mower."""
         mower_attributes = AutomowerEntity.get_mower_attributes(self)
+        action = mower_attributes["planner"]["override"]["action"]
+        action = action.lower() if action is not None else action
         return {
             ATTR_STATUS: self.__get_status(),
-            "action": mower_attributes["planner"]["override"]["action"],
+            "action": action,
         }
 
     async def async_start(self) -> None:


### PR DESCRIPTION
### Support for entity name translation is introduced. 

All entity platforms are supported and there are no breaking changes.
Note that the language for entity name translation is selected globally in HA, Goto Settings->System->General and select language and restart HA. Currently only English and Swedish are supported. Other languages will default to English names. The language of sensor states are controlled by the language setting in your personal profile.

#### Known limitations:
- Some of the strings in the vacuum entity dialog are handled by frontend and there is no support in HA for frontend localization from custom components.
- Dynamic messages e.g. "Schedule, next start Fri 10:00" can not be translated until HA core supports placeholders in this context.


#### Further development in separate PR:s
- Add translation of error status messages - Perhaps not necessary, can be a lot of work to maintain in all languages. One alternative is to "move" all error strings from const.py to en.json and it will be up to the translators to implement in their language when they have the energy.
- Fix other supported language files to simplify for translators. Can wait until the first two languages are verified. @Thomas55555 - What is your native language?

All comments are welcome.