### PR TITLE
Don't raise keyerror during migration, if missing camera key

### DIFF
--- a/custom_components/husqvarna_automower/__init__.py
+++ b/custom_components/husqvarna_automower/__init__.py
@@ -168,7 +168,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             MOWER_IMG_PATH,
             MAP_IMG_PATH,
         ]:
-            new_options.pop(opt_key)
+            new_options.pop(opt_key, None)
 
         config_entry.version = CURRENT_CONFIG_VER
         hass.config_entries.async_update_entry(config_entry, options=new_options)

--- a/custom_components/husqvarna_automower/config_flow.py
+++ b/custom_components/husqvarna_automower/config_flow.py
@@ -435,7 +435,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ]
                 else:
                     errors[HOME_LOCATION] = pnt_error
-            self.options[self.sel_mower_id][ADD_CAMERAS] = user_input.get(ADD_CAMERAS)
+            self.options[self.sel_mower_id][ADD_CAMERAS] = user_input.get(ADD_CAMERAS, [])
 
             if not errors:
                 return await self._update_config()

--- a/custom_components/husqvarna_automower/config_flow.py
+++ b/custom_components/husqvarna_automower/config_flow.py
@@ -435,7 +435,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ]
                 else:
                     errors[HOME_LOCATION] = pnt_error
-            self.options[self.sel_mower_id][ADD_CAMERAS] = user_input.get(ADD_CAMERAS, [])
+            self.options[self.sel_mower_id][ADD_CAMERAS] = user_input.get(
+                ADD_CAMERAS, []
+            )
 
             if not errors:
                 return await self._update_config()


### PR DESCRIPTION
Resolves #494

If user has never configured the camera, the ENABLE_CAMERA key is missing.