### PR TITLE
enable error and problem sensors by default

### DIFF
--- a/custom_components/husqvarna_automower/binary_sensor.py
+++ b/custom_components/husqvarna_automower/binary_sensor.py
@@ -78,7 +78,7 @@ class AutomowerLeavingDockBinarySensor(BinarySensorEntity, AutomowerEntity):
 class AutomowerErrorBinarySensor(BinarySensorEntity, AutomowerEntity):
     """Defining the AutomowerErrorSensor Entity."""
 
-    _attr_entity_registry_enabled_default: bool = False
+    _attr_entity_registry_enabled_default: bool = True
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PROBLEM
     _attr_translation_key = "error"
 

--- a/custom_components/husqvarna_automower/sensor.py
+++ b/custom_components/husqvarna_automower/sensor.py
@@ -238,7 +238,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     AutomowerSensorEntityDescription(
         key="problem_sensor",
         translation_key="problem_list",
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
         device_class=SensorDeviceClass.ENUM,
         options=problem_list(),
         value_fn=lambda data: None


### PR DESCRIPTION
They are more important now, since the status is gone. So they should be enabled by default