### PR TITLE
Fixed Unit deprecation warning

### DIFF
--- a/custom_components/husqvarna_automower/number.py
+++ b/custom_components/husqvarna_automower/number.py
@@ -5,7 +5,7 @@ import logging
 from aiohttp import ClientResponseError
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -45,14 +45,14 @@ NUMBER_SENSOR_TYPES: tuple[NumberEntityDescription, ...] = (
         translation_key="park_for",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
     NumberEntityDescription(
         key="Start",
         translation_key="mow_for",
         icon="mdi:clock-outline",
         entity_registry_enabled_default=True,
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
 )
 


### PR DESCRIPTION
Replaced TIME_MINUTES with UnitOfTime.MINUTES to fix deprecation warning.

Otherwise HA will show the following warning in log:
> TIME_MINUTES was used from husqvarna_automower, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead.